### PR TITLE
Fix bad reference to `self.registered_providers`

### DIFF
--- a/ovos_PHAL_plugin_wallpaper_manager/__init__.py
+++ b/ovos_PHAL_plugin_wallpaper_manager/__init__.py
@@ -243,10 +243,10 @@ class WallpaperManager(PHALPlugin):
                 default_wallpaper = next((wp for wp in wallpaper_collection if wp.endswith(default_wallpaper_name)),
                                          None)
                 if default_wallpaper:
-                    for provider in self.registered_providers:
-                        if provider.get("provider_name") == self.selected_provider:
-                            provider["default_wallpaper"] = default_wallpaper
-                            break
+                    self.registered_providers.get(self.selected_provider,
+                                                  {})["default_wallpaper"] = \
+                        default_wallpaper
+
                 wallpaper_path = default_wallpaper
 
             if wallpaper_path:


### PR DESCRIPTION
Fixes missed refernce to `registered_providers` list that was refactored to a dict for simplified lookups
Missed in #11
Closes #13