### PR TITLE
Resolve failing alpha package automation

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -39,14 +39,14 @@ jobs:
     if: success()  # Ensure this job only runs if the previous job succeeds
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: dev
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: '3.10'
       - name: Install Build Tools
         run: |
           python -m pip install build wheel
@@ -56,8 +56,8 @@ jobs:
       - name: Build Distribution Packages
         run: |
           python setup.py sdist bdist_wheel
-      - name: Publish to Test PyPI
-        uses: pypa/gh-action-pypi-publish@master
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{secrets.PYPI_TOKEN}}
 
@@ -68,12 +68,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout dev branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: dev
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
Update actions versions in release_workflow.yml to latest versions
Update Python version to supported 3.10
Addresses failing action run: https://github.com/OpenVoiceOS/ovos-PHAL-plugin-wallpaper-manager/actions/runs/13010883232/job/36288168593
Updates pypi-publish action per [project readme](https://github.com/pypa/gh-action-pypi-publish/tree/master#readme)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration
	- Upgraded GitHub Actions checkout and setup actions to latest versions
	- Updated Python version from 3.8 to 3.10
	- Replaced PyPI publishing action with newer version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->