### PR TITLE
Resolve failing stable release automation

### DIFF
--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -19,14 +19,14 @@ jobs:
     if: success()  # Ensure this job only runs if the previous job succeeds
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: dev
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: '3.10'
       - name: Install Build Tools
         run: |
           python -m pip install build wheel
@@ -36,8 +36,8 @@ jobs:
       - name: Build Distribution Packages
         run: |
           python setup.py sdist bdist_wheel
-      - name: Publish to Test PyPI
-        uses: pypa/gh-action-pypi-publish@master
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{secrets.PYPI_TOKEN}}
 


### PR DESCRIPTION
Update stable release workflow to usse supported Python and actions versions

Failure noted in https://github.com/OpenVoiceOS/ovos-PHAL-plugin-wallpaper-manager/actions/runs/13908549152
Related to #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the automated release pipeline by updating key dependencies.
	- Upgraded the Python runtime from an older version to 3.10, aligning with modern standards.
	- Adjusted the release workflow to streamline deployments directly to production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->