### PR TITLE
Fix PyPI stable publish action to checkout `master`

### DIFF
--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: master
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
The `publish_stable` job pushes a version change to `master`, but the following job was checking out `dev`, therefore getting the previous alpha version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the release publishing process to source builds from the stable branch, ensuring releases are built from the most reliable code.
	- Refined configuration consistency in internal workflows for improved operational clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->