### PR TITLE
Refactor wallpaper_rotation init

### DIFF
--- a/ovos_PHAL_plugin_wallpaper_manager/__init__.py
+++ b/ovos_PHAL_plugin_wallpaper_manager/__init__.py
@@ -54,10 +54,6 @@ class WallpaperManager(PHALPlugin):
 
         self.bus.on("homescreen.metadata.get", self.handle_homescreen_load)
 
-        if self.wallpaper_rotation:
-            # Start rotation if configured
-            self._start_auto_rotation()
-
         # We cannot guarantee when this plugin will be loaded, so emit a message
         # to any providers that are waiting for the plugin to be loaded, so they
         # can immediately register
@@ -66,6 +62,11 @@ class WallpaperManager(PHALPlugin):
     def handle_homescreen_load(self, message: Message):
         self.bus.emit(Message("homescreen.wallpaper.set",
                               {"url": self.selected_wallpaper}))
+
+        # Start rotation if configured
+        if self.wallpaper_rotation:
+            self._start_auto_rotation()
+
 
     def populate_wallpapers(self):
         LOG.info(f"default wallpapers storage: {self.local_wallpaper_storage}")

--- a/ovos_PHAL_plugin_wallpaper_manager/__init__.py
+++ b/ovos_PHAL_plugin_wallpaper_manager/__init__.py
@@ -53,6 +53,7 @@ class WallpaperManager(PHALPlugin):
         self.bus.on("ovos.wallpaper.manager.get.auto.rotation", self.handle_get_auto_rotation)
 
         self.bus.on("homescreen.metadata.get", self.handle_homescreen_load)
+        self.bus.on("mycroft.ready", self.handle_ready)
 
         # We cannot guarantee when this plugin will be loaded, so emit a message
         # to any providers that are waiting for the plugin to be loaded, so they
@@ -63,10 +64,10 @@ class WallpaperManager(PHALPlugin):
         self.bus.emit(Message("homescreen.wallpaper.set",
                               {"url": self.selected_wallpaper}))
 
+    def handle_ready(self, message: Message):
         # Start rotation if configured
         if self.wallpaper_rotation:
             self._start_auto_rotation()
-
 
     def populate_wallpapers(self):
         LOG.info(f"default wallpapers storage: {self.local_wallpaper_storage}")


### PR DESCRIPTION
Closes #16
Tested on a Mark 2 under Neon Core to troubleshoot an issue reported by @olzeke51
Previous behavior resulted in no rotation when the PHAL plugin was configured for rotation at init, but working rotation when enabled via settings page (I suspect a listener in Qt code somewhere that wasn't loaded before the PHAL plugin)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-rotation now starts only after the system signals readiness, preventing premature wallpaper rotation or flicker at startup so the initially selected wallpaper displays first.

* **Refactor**
  * Startup sequence updated to trigger rotation in response to a readiness event instead of during plugin initialization; no changes to user-facing settings or controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->